### PR TITLE
Add Hosted Zone for Cognito Domain, and required Route 53 records

### DIFF
--- a/infrastructure/dns-records-shared-signals/template.yaml
+++ b/infrastructure/dns-records-shared-signals/template.yaml
@@ -125,7 +125,7 @@ Resources:
   # SSF Cognito User Pool  #
   #########################
 
-  SharedSignalsTransmitterCognitoDnsDelegation:
+  SharedSignalsTransmitterCognitoCnameRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneId: !ImportValue SharedSignalsTransmitterCognitoPublicHostedZoneId

--- a/infrastructure/dns-records-shared-signals/template.yaml
+++ b/infrastructure/dns-records-shared-signals/template.yaml
@@ -120,3 +120,36 @@ Resources:
       Name: SharedSignalsTransmitterApiDomainName
       Type: String
       Value: !Ref SharedSignalsTransmitterApiDomainName
+
+  #########################
+  # SSF Cognito User Pool  #
+  #########################
+
+  SharedSignalsTransmitterCognitoDnsDelegation:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !ImportValue SharedSignalsTransmitterCognitoPublicHostedZoneId
+      Name: !If
+        - IsProduction
+        - auth.shared-signals-transmitter.transaction.account.gov.uk
+        - !Sub auth.ssf-transmitter.transaction.${Environment}.account.gov.uk
+      ResourceRecords: !GetAtt SsfUserPoolDomain.CloudFrontDistribution
+      Type: CNAME
+
+  SsfUserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Properties:
+      CustomDomainConfig:
+        CertificateArn: '{{resolve:ssm:CognitoCustomDomainCertificateArn}}'
+      Domain: !If
+        - IsProduction
+        - shared-signals-transmitter.transaction.account.gov.uk
+        - !Sub ssf-transmitter.transaction.${Environment}.account.gov.uk
+      UserPoolId: '{{resolve:ssm:SSFUserPoolId}}'
+
+  CognitoDomainUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: CognitoDomainUrl
+      Type: String
+      Value: !Ref SsfUserPoolDomain

--- a/infrastructure/dns-zones-shared-signals/template.yaml
+++ b/infrastructure/dns-zones-shared-signals/template.yaml
@@ -38,6 +38,15 @@ Resources:
         - IsProduction
         - shared-signals-transmitter.transaction.account.gov.uk
         - !Sub ssf-transmitter.transaction.${Environment}.account.gov.uk
+  SharedSignalsTransmitterCognitoPublicHostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !If
+        - IsProduction
+        - auth.shared-signals-transmitter.transaction.account.gov.uk
+        - !Sub auth.ssf-transmitter.transaction.${Environment}.account.gov.uk
 
 Outputs:
   SharedSignalsMockReceiverApiPublicHostedZoneNameServers:
@@ -59,3 +68,8 @@ Outputs:
     Value: !GetAtt SharedSignalsTransmitterApiPublicHostedZone.Id
     Export:
       Name: SharedSignalsTransmitterApiPublicHostedZoneId
+
+  SharedSignalsTransmitterCognitoPublicHostedZoneId:
+    Value: !GetAtt SharedSignalsTransmitterCognitoPublicHostedZone.Id
+    Export:
+      Name: SharedSignalsTransmitterCognitoPublicHostedZoneId


### PR DESCRIPTION
Wasn't possible to put Cognito on the same sub-domain as the API, so have gone with a new sub-domain https://auth.shared-signals-transmitter.transaction.accounts.gov.uk.

This involved a new hosted zone, and a CNAME record in the parent hosted zone (the one we use for the API) which points to the Cloudfront distribution provided by the UserPoolDomain resource.

Also moved the UserPoolDomain resource from the infra repo to here. Since this doesn't deploy to dev, have left one in the infra repo that just handles dev, and creates a Cognito Domain instead of a custom one. See - https://github.com/alphagov/di-txma-infra/pull/351